### PR TITLE
fix(submodule): cloning submodule using ssh url

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/sergi/go-diff v1.1.0
+	github.com/whilp/git-urls v1.0.0
 	github.com/xanzy/ssh-agent v0.3.1
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
 	golang.org/x/net v0.0.0-20210326060303-6b1517762897

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,6 @@ github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
 github.com/go-git/gcfg v1.5.0/go.mod h1:5m20vg6GwYabIxaOonVkTdrILxQMpEShl1xiMF4ua+E=
 github.com/go-git/go-billy/v5 v5.3.1 h1:CPiOUAzKtMRvolEKw+bG1PLRpT7D3LIs3/3ey4Aiu34=
 github.com/go-git/go-billy/v5 v5.3.1/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
-github.com/go-git/go-git-fixtures/v4 v4.3.0 h1:OAiwhtOsTVVUvVSLzwSO9PCCo/KPxGfn5aC3BV6d6TY=
-github.com/go-git/go-git-fixtures/v4 v4.3.0/go.mod h1:8LHG1a3SRW71ettAD/jW13h8c6AqjVSeL11RAdgaqpo=
 github.com/go-git/go-git-fixtures/v4 v4.3.1 h1:y5z6dd3qi8Hl+stezc8p3JxDkoTRqMAlKnXHuzrfjTQ=
 github.com/go-git/go-git-fixtures/v4 v4.3.1/go.mod h1:8LHG1a3SRW71ettAD/jW13h8c6AqjVSeL11RAdgaqpo=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
@@ -60,6 +58,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/whilp/git-urls v1.0.0 h1:95f6UMWN5FKW71ECsXRUd3FVYiXdrE7aX4NZKcPmIjU=
+github.com/whilp/git-urls v1.0.0/go.mod h1:J16SAmobsqc3Qcy98brfl5f5+e0clUvg1krgwk/qCfE=
 github.com/xanzy/ssh-agent v0.3.1 h1:AmzO1SSWxw73zxFZPRwaMN1MohDw8UyHnmuxyceTEGo=
 github.com/xanzy/ssh-agent v0.3.1/go.mod h1:QIE4lCeL7nkC25x+yA3LBIYfwCc1TFziCtG7cBAac6w=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=

--- a/submodule.go
+++ b/submodule.go
@@ -5,13 +5,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/url"
 	"path"
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/format/index"
+	url "github.com/whilp/git-urls"
 )
 
 var (
@@ -375,7 +375,7 @@ func (s *SubmoduleStatus) IsClean() bool {
 // the SHA-1 found in the index of the containing repository.
 func (s *SubmoduleStatus) String() string {
 	var extra string
-	var status = ' '
+	status := ' '
 
 	if s.Current.IsZero() {
 		status = '-'


### PR DESCRIPTION
Changed from **`net/url`** stdlib to **[git-urls](https://pkg.go.dev/github.com/whilp/git-urls)**

According to the function description it does the following things:

> Parse parses rawurl into a URL structure. Parse first attempts to find a standard URL with a valid Git transport as its scheme. If that cannot be found, it then attempts to find a SCP-like URL. And if that cannot be found, it assumes rawurl is a local path. If none of these rules apply, Parse returns an error. 

Example:

```
package main

import (
	"fmt"

	url "github.com/whilp/git-urls"
)

func main() {
	http, err := url.Parse("https://github.com/hello/hello.git")
	if err != nil {
		panic(err)
	}

	ssh, err := url.Parse("git@github.com:hello/hello.git")
	if err != nil {
		panic(err)
	}

	fmt.Printf("http: %s\n", http.Path)
	fmt.Printf("ssh: %s\n", ssh.Path)
}

```
returns:
```
http: /hello/hello.git
ssh: hello/hello.git
```


Fixes go-git/go-git#397 