### PR TITLE
chore: fix module org

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-git/go-git/v5
+module github.com/argoproj-labs/go-git/v5
 
 require (
 	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7


### PR DESCRIPTION
module organization needs to be changed from `go-git` to `argoproj-labs`
```
        module declares its path as: github.com/go-git/go-git/v5
                but was required as: github.com/argoproj-labs/go-git/v5
```