### PR TITLE
plumbing: resolve non-external delta references

### DIFF
--- a/plumbing/format/packfile/parser.go
+++ b/plumbing/format/packfile/parser.go
@@ -234,6 +234,15 @@ func (p *Parser) indexObjects() error {
 				return err
 			}
 
+			// move children of placeholder parent into actual parent in case this was
+			// a non-external delta reference
+			if placeholder, ok := p.oiByHash[sha1]; ok {
+				ota.Children = placeholder.Children
+				for _, c := range ota.Children {
+					c.Parent = ota
+				}
+			}
+
 			ota.SHA1 = sha1
 			p.oiByHash[ota.SHA1] = ota
 		}


### PR DESCRIPTION
In a self-contained pack file delta references might point to base objects stored later in the file.
In this case we need to replace placeholders for external refs with the actual base object and update the children references.

Fixes: https://github.com/argoproj/argo-workflows/issues/10225
